### PR TITLE
fix user self destruct

### DIFF
--- a/app/Http/Controllers/TwitterController.php
+++ b/app/Http/Controllers/TwitterController.php
@@ -7,6 +7,7 @@ use App\Helpers\SecurityHelpers;
 use App\Jobs\ReadTweets;
 use App\Models\User;
 use Atymic\Twitter\Facade\Twitter;
+use Carbon\Carbon;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Redirect;
 use Illuminate\Support\Facades\Session;
@@ -84,6 +85,9 @@ class TwitterController extends Controller
         if(!$user){
             throw new \Exception("Unauthorized", 401);
         }
+
+        $user->updated_at = Carbon::now();
+        $user->save();
 
         ReadTweets::dispatch($data);
         return response(["status" => "success"]);

--- a/app/Jobs/DeleteDeactivatedUsers.php
+++ b/app/Jobs/DeleteDeactivatedUsers.php
@@ -31,6 +31,6 @@ class DeleteDeactivatedUsers implements ShouldQueue
      */
     public function handle()
     {
-        User::where("created_at", "<", Carbon::now()->subWeek()->format("Y-m-d"))->delete();
+        User::where("updated_at", "<", Carbon::now()->subWeek()->format("Y-m-d"))->delete();
     }
 }

--- a/app/Jobs/ReadTweets.php
+++ b/app/Jobs/ReadTweets.php
@@ -67,8 +67,5 @@ class ReadTweets implements ShouldQueue
                 now()->addMinutes(15) // because of twitter rate limit you can only remove 50 tweets per 15 minutes
             );
         }
-        else {
-            $user->delete(); // remove user from db when operation is done
-        }
     }
 }


### PR DESCRIPTION
- remove user delete after tweet read if there is no more page, cause it might remove user before removing it's tweets, so private key would not be available anymore to open the blackbox
- update user updated_at field on press kill switch to use it for delete deattive users job
- use updated at field to remove user, cause it can remove user in the middle of removing tweets